### PR TITLE
LAU-396: Up junit5PluginVersion from 0.12 to 0.15

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -166,7 +166,7 @@ jacocoTestReport {
 
 pitest {
     pitestVersion.set('1.7.4')
-    junit5PluginVersion.set('0.12')
+    junit5PluginVersion.set('0.15')
     targetClasses = ['uk.gov.hmcts.reform.laubackend.*']
     excludedClasses = [
             'uk.gov.hmcts.reform.laubackend.idam.madeup.*'


### PR DESCRIPTION
### JIRA link ###
https://tools.hmcts.net/jira/browse/LAU-396

### Change description ###
Up junit5PluginVersion from 0.12 to 0.15

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```