### PR TITLE
lau-408 dependency check fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -285,7 +285,7 @@ def versions = [
         cucumber          : '6.8.0',
         wiremock          : '2.21.0',
         fasterXmlJackson  : '2.13.2',
-        springFramework   : '5.3.19',
+        springFramework   : '5.3.20',
         log4j             : '2.17.2',
         springCloud       : '3.1.2'
 ]

--- a/build.gradle
+++ b/build.gradle
@@ -327,6 +327,20 @@ dependencies {
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-jdbc'
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-security'
 
+    implementation group: 'org.springframework', name:'spring-aop', version: versions.springFramework
+    implementation group: 'org.springframework', name:'spring-aspects', version: versions.springFramework
+    implementation group: 'org.springframework', name:'spring-beans', version: versions.springFramework
+    implementation group: 'org.springframework', name:'spring-context', version: versions.springFramework
+    implementation group: 'org.springframework', name:'spring-core', version: versions.springFramework
+    implementation group: 'org.springframework', name:'spring-expression', version: versions.springFramework
+    implementation group: 'org.springframework', name:'spring-jcl', version: versions.springFramework
+    implementation group: 'org.springframework', name:'spring-jdbc', version: versions.springFramework
+    implementation group: 'org.springframework', name:'spring-orm', version: versions.springFramework
+    implementation group: 'org.springframework', name:'spring-oxm', version: versions.springFramework
+    implementation group: 'org.springframework', name:'spring-tx', version: versions.springFramework
+    implementation group: 'org.springframework', name:'spring-web', version: versions.springFramework
+    implementation group: 'org.springframework', name:'spring-webmvc', version: versions.springFramework
+
     implementation group: 'io.springfox', name: 'springfox-swagger2', version: versions.springfoxSwagger
     implementation group: 'io.springfox', name: 'springfox-swagger-ui', version: versions.springfoxSwaggerui
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/LAU-408


### Change description ###
This change is to fix dependency check related to spring Framework. This has been upgraded from 5.3.19 to 5.3.20


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
