### PR TITLE
LAU-531: Update socket timeout to 60 seconds.

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -31,6 +31,9 @@ spring:
       poolName: LAUIdamHikariCP
       maxLifetime: 7200000
       connectionTimeout: 60000
+      connectionTimeout: 60000
+      data-source-properties:
+        socketTimeout: 60
   #    tomcat:
   #      max-active: 10
   #      max-idle: 10

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -31,7 +31,6 @@ spring:
       poolName: LAUIdamHikariCP
       maxLifetime: 7200000
       connectionTimeout: 60000
-      connectionTimeout: 60000
       data-source-properties:
         socketTimeout: 60
   #    tomcat:


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/LAU-531


### Change description ###
Update SQL socket timeout to 60 seconds to allow long running sql for idam searches.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
