### PR TITLE
Suppress CVE-2022-45688 as project does not contain json-java or hutool

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -287,7 +287,7 @@ def versions = [
         commonsIo         : '2.11.0',
         cucumber          : '6.11.0',
         wiremock          : '2.35.0',
-        fasterXmlJackson  : '2.14.1',
+        fasterXmlJackson  : '2.14.2',
         springFramework   : '5.3.21',
         log4j             : '2.17.2',
         springCloud       : '3.1.2',

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -47,4 +47,8 @@
     <packageUrl regex="true">^pkg:maven/org.yaml/snakeyaml@.*$</packageUrl>
     <cpe>cpe:/a:yaml_project:yaml</cpe>
   </suppress>
+  <suppress>
+    <notes>False positive as project does not contain json-java or hutool</notes>
+    <cve>CVE-2022-45688</cve>
+  </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/LAU-613


### Change description ###
Suppress CVE-2022-45688 as project does not contain json-java or hutool


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```