### PR TITLE
LAU-646 upgrade vulnerable to CVE-2023-20863 libraries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ plugins {
     id 'pmd'
     id 'jacoco'
     id 'io.spring.dependency-management' version '1.1.0'
-    id 'org.springframework.boot' version '2.7.0'
+    id 'org.springframework.boot' version '2.7.11'
     id 'org.owasp.dependencycheck' version '8.2.1'
     id 'com.github.ben-manes.versions' version '0.46.0'
     id 'org.sonarqube' version '4.0.0.2929'
@@ -288,10 +288,10 @@ def versions = [
         cucumber          : '6.11.0',
         wiremock          : '2.35.0',
         fasterXmlJackson  : '2.14.2',
-        springFramework   : '5.3.26',
+        springFramework   : '5.3.27',
         log4j             : '2.17.2',
         springCloud       : '3.1.2',
-        springSecurity    : '5.7.5'
+        springSecurity    : '5.7.8'
 ]
 
 ext.libraries = [


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/LAU-646

### Change description ###

Minor versions bump to address CVE-2023-20863 vulnerability

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```