### PR TITLE
LAU-681 suppress CVE-2023-35116, seems like not considered as CVE

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ plugins {
     id 'org.flywaydb.flyway' version '9.20.0'
     id 'org.owasp.dependencycheck' version '8.3.1'
     id 'org.sonarqube' version '4.2.0.3129'
-    id 'org.springframework.boot' version '3.0.6'
+    id 'org.springframework.boot' version '3.0.8'
     id 'uk.gov.hmcts.java' version '0.12.43'
     id "info.solidsoft.pitest" version '1.9.11'
     id "org.springdoc.openapi-gradle-plugin" version "1.6.0"
@@ -314,7 +314,7 @@ dependencies {
     implementation group: 'org.postgresql', name: 'postgresql', version: '42.6.0'
     implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version:versions.log4j
     implementation group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version:versions.log4j
-    implementation group: "com.networknt", name: "json-schema-validator", version: "1.0.80"
+    implementation group: "com.networknt", name: "json-schema-validator", version: "1.0.85"
     implementation group: 'org.projectlombok', name: 'lombok', version: versions.lombok
     implementation group: 'org.springframework.boot', name: 'spring-boot-devtools'
     implementation group: 'commons-fileupload', name: 'commons-fileupload', version: '1.5'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,53 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-  <suppress until="2030-01-01">
-    <notes><![CDATA[
-     Suppressing as it's a false positive (see: https://pivotal.io/security/cve-2018-1258)
-   ]]></notes>
-    <gav regex="true">^org\.springframework\.security:spring-security-crypto:5.4.[0-5]</gav>
-    <cpe>cpe:/a:pivotal_software:spring_security</cpe>
-    <cve>CVE-2018-1258</cve>
-  </suppress>
   <suppress>
     <notes><![CDATA[
-        CVE is a json vulnerability for Node projects. False positive reported at https://github.com/jeremylong/DependencyCheck/issues/2794
+      name: jackson-databind
+      Does not seem to be considered as CVE: https://github.com/FasterXML/jackson-databind/issues/3972
     ]]></notes>
-    <cve>CVE-2020-10663</cve>
-    <cve>CVE-2020-7712</cve>
-    <cve>CVE-2021-42340</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[name: spring-plugin-core and spring-plugin-metadata 2.0.0.RELEASE]]></notes>
-    <cve>CVE-2013-4152</cve>
-    <cve>CVE-2013-7315</cve>
-    <cve>CVE-2014-0054</cve>
-    <cve>CVE-2016-1000027</cve>
-    <cve>CVE-2022-22965</cve>
-    <cve>CVE-2022-22968</cve>
-    <cve>CVE-2022-22976</cve>
-    <cve>CVE-2022-22978</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[name: spring-boot 3.0.6]]></notes>
-    <cve>CVE-2023-20883</cve>
-  </suppress>
-  <suppress>
-    <packageUrl regex="true">^pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@.*$</packageUrl>
-    <cve>CVE-2022-34305</cve>
-  </suppress>
-  <suppress>
-    <packageUrl regex="true">^pkg:maven/org.apache.tomcat.embed/tomcat-embed-websocket@.*$</packageUrl>
-    <cve>CVE-2022-34305</cve>
-  </suppress>
-  <suppress until="2023-01-07">
-    <cve>CVE-2022-31569</cve>
-  </suppress>
-  <suppress>
-    <packageUrl regex="true">^pkg:maven/org.yaml/snakeyaml@.*$</packageUrl>
-    <cve>CVE-2022-1471</cve>
-  </suppress>
-  <suppress>
-    <notes>False positive as project does not contain json-java or hutool</notes>
-    <cve>CVE-2022-45688</cve>
+    <cve>CVE-2023-35116</cve>
   </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/LAU-681

### Change description ###

Suppress CVE-2023-35116 as it doesn't seem to be CVE

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```