### PR TITLE
LAU-686 delete accounts delete endpoint

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -256,17 +256,17 @@ def versions = [
         junitPlatform     : '1.9.3',
         springBoot        : springBoot.class.package.implementationVersion,
         serenity          : '3.7.1',
-        gradlePitest      : '1.9.0',
+        gradlePitest      : '1.9.11',
         sonarPitest       : '0.5',
-        lombok            : '1.18.26',
-        testcontainers    : '1.17.6',
-        restAssured       : '5.3.0',
+        lombok            : '1.18.28',
+        testcontainers    : '1.18.3',
+        restAssured       : '5.3.1',
         serviceAuthVersion: '5.0.0',
-        commonsIo         : '2.11.0',
-        cucumber          : '7.12.0',
+        commonsIo         : '2.13.0',
+        cucumber          : '7.12.1',
         wiremock          : '2.35.0',
         log4j             : '2.20.0',
-        springCloud       : '4.0.2',
+        springCloud       : '4.0.3',
         reformLogging     : '6.0.1',
         idamClient        : '3.0.0'
 ]
@@ -295,8 +295,8 @@ dependencies {
     implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-bootstrap', version: versions.springCloud
     implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-openfeign', version: versions.springCloud
     implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.1.0'
-    implementation group: 'com.microsoft.azure', name: 'applicationinsights-core', version: '3.4.12'
-    implementation group: 'com.microsoft.azure', name: 'applicationinsights-web', version: '3.4.12'
+    implementation group: 'com.microsoft.azure', name: 'applicationinsights-core', version: '3.4.14'
+    implementation group: 'com.microsoft.azure', name: 'applicationinsights-web', version: '3.4.14'
     implementation group: 'org.flywaydb', name: 'flyway-core', version: '9.19.1'
     implementation group: 'org.postgresql', name: 'postgresql', version: '42.6.0'
     implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version:versions.log4j
@@ -311,7 +311,7 @@ dependencies {
     implementation group: 'com.github.hmcts', name: 'idam-java-client', version: versions.idamClient
     implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: versions.reformLogging
     implementation group: 'jakarta.servlet', name: 'jakarta.servlet-api', version: '6.0.0'
-    implementation group: 'org.glassfish.jaxb', name: 'jaxb-runtime', version: '4.0.2'
+    implementation group: 'org.glassfish.jaxb', name: 'jaxb-runtime', version: '4.0.3'
 
     testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test'
     testImplementation group: 'net.serenity-bdd', name: 'serenity-core', version: versions.serenity
@@ -364,7 +364,7 @@ dependencies {
     testImplementation group: 'io.rest-assured', name: 'rest-assured', version: versions.restAssured
     testImplementation group: 'io.rest-assured', name: 'json-path', version: versions.restAssured
     testImplementation group: 'io.rest-assured', name: 'xml-path', version: versions.restAssured
-    testImplementation group: 'com.google.code.gson', name: 'gson', version: '2.10'
+    testImplementation group: 'com.google.code.gson', name: 'gson', version: '2.10.1'
     testImplementation group: 'com.googlecode.junit-toolbox', name: 'junit-toolbox', version: '2.4'
     testImplementation group: 'org.testng', name: 'testng', version: '7.8.0'
 

--- a/src/functionalTest/java/uk/gov/hmcts/reform/laubackend/idam/serenityfunctionaltests/helper/DatabaseCleaner.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/laubackend/idam/serenityfunctionaltests/helper/DatabaseCleaner.java
@@ -3,42 +3,77 @@ package uk.gov.hmcts.reform.laubackend.idam.serenityfunctionaltests.helper;
 import com.google.gson.Gson;
 import io.restassured.RestAssured;
 import io.restassured.response.Response;
+import lombok.extern.slf4j.Slf4j;
 import org.json.JSONException;
+import uk.gov.hmcts.reform.laubackend.idam.serenityfunctionaltests.model.DeletedAccount;
+import uk.gov.hmcts.reform.laubackend.idam.serenityfunctionaltests.model.DeletedAccountsResponse;
 import uk.gov.hmcts.reform.laubackend.idam.serenityfunctionaltests.model.LogonLogPostResponseVO;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
+import static org.springframework.http.HttpStatus.NO_CONTENT;
 import static org.springframework.http.HttpStatus.OK;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static uk.gov.hmcts.reform.laubackend.idam.constants.CommonConstants.AUTHORISATION_HEADER;
 import static uk.gov.hmcts.reform.laubackend.idam.constants.CommonConstants.SERVICE_AUTHORISATION_HEADER;
 import static uk.gov.hmcts.reform.laubackend.idam.serenityfunctionaltests.config.EnvConfig.API_URL;
-import static uk.gov.hmcts.reform.laubackend.idam.serenityfunctionaltests.utils.TestConstants.LOGON_DELETE_ENDPOINT;
+import static uk.gov.hmcts.reform.laubackend.idam.serenityfunctionaltests.utils.TestConstants.DELETED_ACCOUNTS_DELETE_ENDPOINT;
 import static uk.gov.hmcts.reform.laubackend.idam.serenityfunctionaltests.utils.TestConstants.FRONTEND_SERVICE_NAME;
+import static uk.gov.hmcts.reform.laubackend.idam.serenityfunctionaltests.utils.TestConstants.LOGON_DELETE_ENDPOINT;
 
+@Slf4j
 public final class DatabaseCleaner {
 
     private DatabaseCleaner() {
     }
 
-    public static void deleteLogonRecord(final Response response) throws JSONException {
+    public static void deleteLogonRecord(final Response response) {
         final Gson jsonReader = new Gson();
-        final AuthorizationHeaderHelper authorizationHeaderHelper = new AuthorizationHeaderHelper();
 
         final LogonLogPostResponseVO logonLogPostResponse = jsonReader
                 .fromJson(response.getBody().asString(), LogonLogPostResponseVO.class);
 
+        try {
+            makeRequest(LOGON_DELETE_ENDPOINT, "logonId", logonLogPostResponse.getLogonLog().getId(), OK.value());
+        } catch (JSONException je) {
+            log.error(je.getMessage(), je);
+        }
+    }
+
+    public static void deleteDeletedAccountRecord(Response response) {
+        final Gson jsonReader = new Gson();
+        var deletedAccountsResponse = jsonReader.fromJson(
+            response.getBody().asString(),
+            DeletedAccountsResponse.class);
+
+        try {
+            for (DeletedAccount deletedAccount: deletedAccountsResponse.getDeletionLogs()) {
+                var userId = deletedAccount.getUserId();
+                makeRequest(DELETED_ACCOUNTS_DELETE_ENDPOINT, "userId", userId, NO_CONTENT.value());
+            }
+        } catch (JSONException je) {
+            log.error(je.getMessage(), je);
+        }
+    }
+
+    private static void makeRequest(
+        String endpoint,
+        String paramName,
+        String paramValue,
+        int expectedStatusCode) throws JSONException {
+
+        final AuthorizationHeaderHelper authorizationHeaderHelper = new AuthorizationHeaderHelper();
         final Response deleteResponse = RestAssured
-                .given()
-                .relaxedHTTPSValidation()
-                .baseUri(API_URL + LOGON_DELETE_ENDPOINT)
-                .queryParam("logonId", logonLogPostResponse.getLogonLog().getId())
-                .header(CONTENT_TYPE, APPLICATION_JSON_VALUE)
-                .header(SERVICE_AUTHORISATION_HEADER, authorizationHeaderHelper.getServiceToken(FRONTEND_SERVICE_NAME))
-                .header(AUTHORISATION_HEADER, authorizationHeaderHelper.getAuthorizationToken())
-                .when()
-                .delete()
-                .andReturn();
-        assertThat(deleteResponse.getStatusCode()).isEqualTo(OK.value());
+            .given()
+            .relaxedHTTPSValidation()
+            .baseUri(API_URL + endpoint)
+            .queryParam(paramName, paramValue)
+            .header(CONTENT_TYPE, APPLICATION_JSON_VALUE)
+            .header(SERVICE_AUTHORISATION_HEADER, authorizationHeaderHelper.getServiceToken(FRONTEND_SERVICE_NAME))
+            .header(AUTHORISATION_HEADER, authorizationHeaderHelper.getAuthorizationToken())
+            .when()
+            .delete()
+            .andReturn();
+        assertThat(deleteResponse.getStatusCode()).isEqualTo(expectedStatusCode);
     }
 }

--- a/src/functionalTest/java/uk/gov/hmcts/reform/laubackend/idam/serenityfunctionaltests/model/DeletedAccountsResponse.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/laubackend/idam/serenityfunctionaltests/model/DeletedAccountsResponse.java
@@ -1,0 +1,15 @@
+package uk.gov.hmcts.reform.laubackend.idam.serenityfunctionaltests.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class DeletedAccountsResponse {
+
+    private List<DeletedAccount> deletionLogs;
+}

--- a/src/functionalTest/java/uk/gov/hmcts/reform/laubackend/idam/serenityfunctionaltests/runner/DeletedAccountsApiTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/laubackend/idam/serenityfunctionaltests/runner/DeletedAccountsApiTest.java
@@ -16,6 +16,8 @@ import uk.gov.hmcts.reform.laubackend.idam.serenityfunctionaltests.utils.TestCon
 
 import java.util.Map;
 
+import static uk.gov.hmcts.reform.laubackend.idam.serenityfunctionaltests.helper.DatabaseCleaner.deleteDeletedAccountRecord;
+
 
 @RunWith(SerenityRunner.class)
 public class DeletedAccountsApiTest {
@@ -46,6 +48,9 @@ public class DeletedAccountsApiTest {
             TestConstants.SUCCESS,
             "DeletedAccounts POST API response code 201 assertion is not successful"
         );
+
+        // Cleanup DB
+        deleteDeletedAccountRecord(response);
     }
 
     @Test
@@ -135,7 +140,7 @@ public class DeletedAccountsApiTest {
 
     @Test
     @Title("Assert response code unauthorized request without authentication token")
-    public void assertUnauthorizedRequest() throws JsonProcessingException, JSONException {
+    public void assertUnauthorizedRequest() {
 
         String serviceToken = getApiSteps.givenAValidServiceTokenIsGenerated(
             TestConstants.USER_DISPOSER_SERVICE_NAME);
@@ -157,7 +162,7 @@ public class DeletedAccountsApiTest {
 
     @Test
     @Title("Assert response code forbidden without s2s authentication token")
-    public void assertGetHttpForbiddenWithInvalidS2SToken() throws JsonProcessingException {
+    public void assertGetHttpForbiddenWithInvalidS2SToken() {
 
         Response response = getApiSteps.performGetOperation(
             TestConstants.DELETED_ACCOUNTS_ENDPOINT,

--- a/src/functionalTest/java/uk/gov/hmcts/reform/laubackend/idam/serenityfunctionaltests/utils/TestConstants.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/laubackend/idam/serenityfunctionaltests/utils/TestConstants.java
@@ -15,6 +15,7 @@ public final class TestConstants {
 
     /* deleted accounts endpoint */
     public static final String DELETED_ACCOUNTS_ENDPOINT = "/audit/deletedAccounts";
+    public static final String DELETED_ACCOUNTS_DELETE_ENDPOINT = "/audit/idamUser/deleteIdamUserRecord";
 
     // Authorization constants
     public static final String GRANT_TYPE = "password";

--- a/src/integrationTest/java/uk/gov/hmcts/reform/laubackend/idam/bdd/CommonSteps.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/laubackend/idam/bdd/CommonSteps.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.laubackend.idam.bdd;
 
+import io.cucumber.java.en.And;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
@@ -16,12 +17,12 @@ import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static uk.gov.hmcts.reform.laubackend.idam.helper.RestHelper.getResponseWithoutAuthorizationHeader;
 
-public class CommonSteps {
+public class CommonSteps extends AbstractSteps {
 
     @LocalServerPort
     private int port;
 
-    private int httpStatusResponseCode;
+    protected Response response;
 
     final RestHelper restHelper = new RestHelper();
 
@@ -45,34 +46,42 @@ public class CommonSteps {
 
     @When("And I GET {string} without service authorization header")
     public void searchIdamLogonWithoutAuthHeader(final String path) {
-        final Response response = RestHelper.getResponseWithoutHeader(getUrl(path));
-        httpStatusResponseCode = response.getStatusCode();
+        response = RestHelper.getResponseWithoutHeader(getUrl(path));
     }
 
     @When("I request GET {string} endpoint without mandatory params")
     public void requestWithoutMandatoryParams(final String path) {
-        final Response response = restHelper.getResponse(getUrl(path), Map.of("nonExistingParam", "nonExistingValue"));
-        httpStatusResponseCode = response.getStatusCode();
+        response = restHelper.getResponse(getUrl(path), Map.of("nonExistingParam", "nonExistingValue"));
     }
 
     @Then("HTTP {string} Forbidden response is returned")
     public void assertResponseCode(final String responseCode) {
-        assertThat(httpStatusResponseCode).isEqualTo(parseInt(responseCode));
+        assertThat(response.getStatusCode()).isEqualTo(parseInt(responseCode));
     }
 
     @When("And I GET {string} without authorization header")
     public void searchWithoutAuthorizationHeader(final String path) {
-        final Response response = getResponseWithoutAuthorizationHeader(getUrl(path));
-        httpStatusResponseCode = response.getStatusCode();
+        response = getResponseWithoutAuthorizationHeader(getUrl(path));
     }
 
     @Then("HTTP {string} Bad Request response is returned")
     public void assertErrorResponse(final String errorCode) {
-        assertThat(httpStatusResponseCode).isEqualTo(parseInt(errorCode));
+        assertThat(response.getStatusCode()).isEqualTo(parseInt(errorCode));
     }
 
     @Then("HTTP {string} Unauthorized response is returned")
     public void assertUnauthorizedResponse(final String responseCode) {
-        assertThat(httpStatusResponseCode).isEqualTo(parseInt(responseCode));
+        assertThat(response.getStatusCode()).isEqualTo(parseInt(responseCode));
     }
+
+    @And("I request DELETE {string} endpoint with missing s2s header")
+    public void deleteWithMissingHeader(final String endpoint) {
+        response = restHelper.deleteResponseWithoutServiceAuthHeader(getUrl(endpoint));
+    }
+
+    @And("I request DELETE {string} endpoint with missing authorization header")
+    public void deleteLogonLogWithMissingAuthHeader(final String endpoint) {
+        response = restHelper.deleteResponseWithoutAuthHeader(getUrl(endpoint));
+    }
+
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/laubackend/idam/bdd/LogonAuditDeleteSteps.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/laubackend/idam/bdd/LogonAuditDeleteSteps.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.reform.laubackend.idam.bdd;
 
-import com.google.gson.Gson;
 import io.cucumber.java.Before;
 import io.cucumber.java.en.And;
 import io.cucumber.java.en.Then;
@@ -25,7 +24,7 @@ public class LogonAuditDeleteSteps extends AbstractSteps {
 
     private int httpStatusResponseCode;
     private String logonLogResponseBody;
-    private final Gson jsonReader = new Gson();
+
     private String logonId;
 
     @Before
@@ -60,19 +59,6 @@ public class LogonAuditDeleteSteps extends AbstractSteps {
                                  START_TIME_PARAMETER, START_TIME, END_TIME_PARAMETER, END_TIME));
         logonLogResponseBody = response.getBody().asString();
     }
-
-    @And("I request DELETE {string} logon endpoint with missing s2s header")
-    public void deleteLogonLogWithMissingHeader(final String path) {
-        final Response response = restHelper.deleteResponseWithoutServiceAuthHeader(baseUrl() + path);
-        httpStatusResponseCode = response.getStatusCode();
-    }
-
-    @And("I request DELETE {string} logon endpoint with missing authorization header")
-    public void deleteLogonLogWithMissingAuthHeader(final String path) {
-        final Response response = restHelper.deleteResponseWithoutAuthHeader(baseUrl() + path);
-        httpStatusResponseCode = response.getStatusCode();
-    }
-
 
     @And("I request DELETE {string} logon endpoint with invalid logonId {string}")
     public void deleteLogonLogWithInvalidLogonLogId(final String path, final String logonId) {

--- a/src/integrationTest/java/uk/gov/hmcts/reform/laubackend/idam/bdd/UserDeletionAuditDeleteSteps.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/laubackend/idam/bdd/UserDeletionAuditDeleteSteps.java
@@ -1,0 +1,40 @@
+package uk.gov.hmcts.reform.laubackend.idam.bdd;
+
+import com.google.gson.Gson;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import io.restassured.response.Response;
+import uk.gov.hmcts.reform.laubackend.idam.response.UserDeletionGetResponse;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class UserDeletionAuditDeleteSteps extends AbstractSteps {
+
+    private final Gson jsonReader = new Gson();
+    private Response response;
+
+    @When("I request DELETE {string} with user id {string}")
+    public void deleteUserDeletionAuditByUserId(String endpoint, String userId) {
+        response = restHelper.deleteResponse(baseUrl() + endpoint, "userId", userId);
+    }
+
+    @Then("{int} response is returned")
+    public void assertResponse(int statusCode) {
+        assertThat(statusCode).isEqualTo(response.getStatusCode());
+    }
+
+    @Then("An empty GET {string} response returned for the params:")
+    public void anEmptyGetResponseReturned(String endpoint, Map<String, String> params) {
+        final Response getResponse = restHelper.getResponse(baseUrl() + endpoint, params);
+        assertThat(getResponse.getStatusCode()).isEqualTo(200);
+        var responseBody = jsonReader.fromJson(getResponse.getBody().asString(), UserDeletionGetResponse.class);
+        assertThat(responseBody.getDeletionLogs()).isEmpty();
+    }
+
+    @Then("HTTP {string} {string} response is returned")
+    public void assertHttpResponse(String statusCode, String status) {
+        assertThat(Integer.parseInt(statusCode)).isEqualTo(response.getStatusCode());
+    }
+}

--- a/src/integrationTest/resources/features/delete_logon_audit.feature
+++ b/src/integrationTest/resources/features/delete_logon_audit.feature
@@ -9,13 +9,13 @@ Feature: The application's DELETE logon endpoint
 
   Scenario: The backend is unable to process logon DELETE requests due to missing s2s header
     Given LAU IdAm backend application is healthy
-    And I request DELETE "/audit/logon/deleteAuditLogonRecord" logon endpoint with missing s2s header
-    Then http "403" response is returned for DELETE logon
+    And I request DELETE "/audit/logon/deleteAuditLogonRecord" endpoint with missing s2s header
+    Then HTTP "403" Forbidden response is returned
 
   Scenario: The backend is unable to process logon DELETE requests due to invalid authorization header
     Given LAU IdAm backend application is healthy
-    And I request DELETE "/audit/logon/deleteAuditLogonRecord" logon endpoint with missing authorization header
-    Then http "401" response is returned for DELETE logon
+    And I request DELETE "/audit/logon/deleteAuditLogonRecord" endpoint with missing authorization header
+    Then HTTP "401" Unauthorized response is returned
 
   Scenario: The backend is unable to process logon DELETE requests due invalid case search id
     Given LAU IdAm backend application is healthy

--- a/src/integrationTest/resources/features/delete_user_deletion_audit.feature
+++ b/src/integrationTest/resources/features/delete_user_deletion_audit.feature
@@ -1,0 +1,32 @@
+Feature: The application's DELETE user deletion endpoint
+
+  Background:
+    Given LAU IdAm backend application is healthy
+
+  Scenario: The backend is able to process user deletion DELETE requests
+    When I POST IdAM user deletion data to "/audit/deletedAccounts" endpoint using s2s with data:
+      |user id |email address       |first name|last name|deletion timestamp       |
+      |12345   |email1@example.net  |John      |Smith    |2023-05-20T11:32:43.433Z |
+    And I request DELETE "/audit/idamUser/deleteIdamUserRecord" with user id "12345"
+    Then 204 response is returned
+    And An empty GET "/audit/deletedAccounts" response returned for the params:
+      | userId         | 12345               |
+      | startTimestamp | 2023-04-04T12:23:34 |
+      | endTimestamp   | 2023-06-04T12:23:34 |
+
+  Scenario: The backend is unable to process DELETE requests due to missing s2s header
+    When I request DELETE "/audit/idamUser/deleteIdamUserRecord" endpoint with missing s2s header
+    Then HTTP "403" Forbidden response is returned
+
+  Scenario: The backend is unable to process logon DELETE requests due to invalid authorization header
+    When I request DELETE "/audit/idamUser/deleteIdamUserRecord" endpoint with missing authorization header
+    Then HTTP "401" Unauthorized response is returned
+
+  Scenario: The backend is unable to process logon DELETE requests due invalid user id
+    When I request DELETE "/audit/idamUser/deleteIdamUserRecord" with user id "00000"
+    Then HTTP "404" "Not Found" response is returned
+
+  Scenario: The backend is unable to process logon DELETE requests due invalid user id
+    When I request DELETE "/audit/idamUser/deleteIdamUserRecord" with user id ""
+    Then HTTP "400" "Bad Request" response is returned
+

--- a/src/main/java/uk/gov/hmcts/reform/laubackend/idam/controllers/UserDeletionAuditDeleteController.java
+++ b/src/main/java/uk/gov/hmcts/reform/laubackend/idam/controllers/UserDeletionAuditDeleteController.java
@@ -1,0 +1,82 @@
+package uk.gov.hmcts.reform.laubackend.idam.controllers;
+
+import io.swagger.v3.oas.annotations.Hidden;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
+import uk.gov.hmcts.reform.laubackend.idam.exceptions.InvalidRequestException;
+import uk.gov.hmcts.reform.laubackend.idam.service.UserDeletionAuditService;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static uk.gov.hmcts.reform.laubackend.idam.utils.InputParamsVerifierHelper.verifyIdNotEmpty;
+
+@Hidden
+@RestController
+@Slf4j
+@Tag(
+    name = "IdAM user deletion audit entries DELETE operation",
+    description = "Deletion endpoint to facilitate cleanup after functional and e2e tests"
+)
+@RequiredArgsConstructor
+public class UserDeletionAuditDeleteController {
+
+    private final UserDeletionAuditService service;
+
+    public static final String DELETE_ENDPOINT = "/audit/idamUser/deleteIdamUserRecord";
+
+    @Operation(
+        tags = "DELETE end-point",
+        summary = "Delete IdAM user deletion audit record from the database",
+        description = "This API will delete a record from the lau-idam database for the given entry id. "
+        + "It is only intended to be called from the test API for testing purposes"
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "204",
+            description = "UserDeletionAudit record has been deleted"),
+        @ApiResponse(responseCode = "401", description = "Unauthorized"),
+        @ApiResponse(responseCode = "403", description = "Forbidden"),
+        @ApiResponse(responseCode = "404", description = "IdAM user deletion audit id not found in the database"),
+        @ApiResponse(responseCode = "400", description = "Missing IdAM user deletion audit id from the API request"),
+        @ApiResponse(responseCode = "500", description = "Internal Server Error")
+    })
+    @DeleteMapping(
+        path = UserDeletionAuditDeleteController.DELETE_ENDPOINT,
+        produces = APPLICATION_JSON_VALUE,
+        consumes = APPLICATION_JSON_VALUE
+    )
+    @ResponseBody
+    public ResponseEntity<Object> deleteUserDeletionAudit(@RequestParam("userId") String userId) {
+        try {
+            verifyIdNotEmpty(userId);
+            service.verifyUserIdExists(userId);
+            service.deleteUserDeletionByUserId(userId);
+            return new ResponseEntity<>(null, HttpStatus.NO_CONTENT);
+        } catch (InvalidRequestException ire) {
+            return getExceptionResponseEntity(ire, HttpStatus.BAD_REQUEST);
+        } catch (EmptyResultDataAccessException erdae) {
+            return getExceptionResponseEntity(erdae, HttpStatus.NOT_FOUND);
+        } catch (Exception e) {
+            return getExceptionResponseEntity(e, HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    private ResponseEntity<Object> getExceptionResponseEntity(final Exception exception, final HttpStatus httpStatus) {
+        log.error(
+            "deleteLogonLog API call failed due to error - {}",
+            exception.getMessage(),
+            exception
+        );
+        return new ResponseEntity<>(null, httpStatus);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/laubackend/idam/repository/UserDeletionAuditRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/laubackend/idam/repository/UserDeletionAuditRepository.java
@@ -6,4 +6,8 @@ import uk.gov.hmcts.reform.laubackend.idam.domain.UserDeletionAudit;
 
 @Repository
 public interface UserDeletionAuditRepository extends JpaRepository<UserDeletionAudit, Long> {
+
+    boolean existsUserDeletionAuditByUserId(String userId);
+
+    void deleteUserDeletionAuditByUserId(String userId);
 }

--- a/src/main/java/uk/gov/hmcts/reform/laubackend/idam/service/UserDeletionAuditService.java
+++ b/src/main/java/uk/gov/hmcts/reform/laubackend/idam/service/UserDeletionAuditService.java
@@ -1,8 +1,10 @@
 package uk.gov.hmcts.reform.laubackend.idam.service;
 
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.BooleanUtils;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -93,6 +95,17 @@ public class UserDeletionAuditService {
 
     private long calculateStartRecordNumber(final Page<UserDeletionAudit> users) {
         return users.getSize() * users.getNumber() + 1L;
+    }
+
+    @Transactional
+    public void deleteUserDeletionByUserId(final String userDeletionId) {
+        userDeletionAuditRepository.deleteUserDeletionAuditByUserId(userDeletionId);
+    }
+
+    public void verifyUserIdExists(String userId) {
+        if (!userDeletionAuditRepository.existsUserDeletionAuditByUserId(userId)) {
+            throw new EmptyResultDataAccessException(1);
+        }
     }
 
 

--- a/src/test/java/uk/gov/hmcts/reform/laubackend/idam/controllers/UserDeletionAuditDeleteControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/laubackend/idam/controllers/UserDeletionAuditDeleteControllerTest.java
@@ -1,0 +1,78 @@
+package uk.gov.hmcts.reform.laubackend.idam.controllers;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.http.HttpStatus;
+import uk.gov.hmcts.reform.laubackend.idam.service.UserDeletionAuditService;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@TestInstance(TestInstance.Lifecycle.PER_METHOD)
+class UserDeletionAuditDeleteControllerTest {
+
+    @Mock
+    private UserDeletionAuditService userDeletionAuditService;
+
+    @InjectMocks
+    private UserDeletionAuditDeleteController controller;
+
+    @Test
+    void shouldReturnResponseEntityForDeleteUserDeletionRequest() {
+        doNothing().when(userDeletionAuditService).deleteUserDeletionByUserId("1");
+        var response = controller.deleteUserDeletionAudit("1");
+        verify(userDeletionAuditService, times(1)).deleteUserDeletionByUserId("1");
+        assertEquals(
+            HttpStatus.NO_CONTENT,
+            response.getStatusCode(),
+            "Expected NO_CONTENT, but got " + response.getStatusCode());
+    }
+
+    @Test
+    void shouldReturnBadRequest() {
+        var response = controller.deleteUserDeletionAudit(null);
+        assertEquals(
+            HttpStatus.BAD_REQUEST,
+            response.getStatusCode(),
+            "Expected BAD_REQUEST, but got " + response.getStatusCode()
+        );
+    }
+
+    @Test
+    void shouldReturnNotFound() {
+        doThrow(new EmptyResultDataAccessException(1))
+            .when(userDeletionAuditService)
+            .deleteUserDeletionByUserId("1");
+        var response = controller.deleteUserDeletionAudit("1");
+        verify(userDeletionAuditService, times(1)).deleteUserDeletionByUserId("1");
+        assertEquals(
+            HttpStatus.NOT_FOUND,
+            response.getStatusCode(),
+            "Expected NOT_FOUND, but got " + response.getStatusCode()
+        );
+    }
+
+    @Test
+    void shouldReturnInternalServerError() {
+        doThrow(new RuntimeException())
+            .when(userDeletionAuditService)
+            .deleteUserDeletionByUserId("1");
+
+        var response = controller.deleteUserDeletionAudit("1");
+        verify(userDeletionAuditService, times(1)).deleteUserDeletionByUserId("1");
+        assertEquals(
+            HttpStatus.INTERNAL_SERVER_ERROR,
+            response.getStatusCode(),
+            "Expected INTERNAL_SERVER_ERROR, but got " + response.getStatusCode()
+        );
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/laubackend/idam/service/UserDeletionAuditServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/laubackend/idam/service/UserDeletionAuditServiceTest.java
@@ -158,6 +158,12 @@ class UserDeletionAuditServiceTest {
         assertEquals(timestampStr, response.get(0).getDeletionTimestamp(), "Timestamps are not equal");
     }
 
+    @Test
+    void shouldDeleteUserDeletion() {
+        userDeletionAuditService.deleteUserDeletionByUserId("1");
+        verify(userDeletionAuditRepository, times(1)).deleteUserDeletionAuditByUserId("1");
+    }
+
     private UserDeletionAudit getUserDeletionAudit() {
         return UserDeletionAudit.builder()
             .userId("1")


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/projects/LAU/issues/LAU-686

### Change description ###

Added DELETE deletedAccounts endpoint to cleanup DB after tests

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```