### PR TITLE
Revert fortify-client to regular versioning

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -386,9 +386,7 @@ dependencies {
     testImplementation group: 'com.github.tomakehurst', name: 'wiremock-jre8-standalone', version: versions.wiremock
     testImplementation group: 'org.testcontainers', name: 'testcontainers', version: versions.testcontainers
     testImplementation group: 'org.testcontainers', name: 'postgresql', version: versions.testcontainers
-    // using commit hash for a version, as 1.4.1 version doesn't have latest logback-classic version
-    // and that prevents spring boot 3.3.0 upgrade
-    testImplementation group: 'com.github.hmcts', name: 'fortify-client', version: '6623c6c811', classifier: 'all'
+    testImplementation group: 'com.github.hmcts', name: 'fortify-client', version: '1.4.2', classifier: 'all'
     testImplementation group: 'jakarta.el', name: 'jakarta.el-api', version: '6.0.0'
     testImplementation group: 'net.sourceforge.htmlunit', name: 'htmlunit', version: '2.70.0'
 


### PR DESCRIPTION
### Change description ###
Revert fortify-client to use regular versions as they release a new one with the updates needed for spring-boot 3.3.0